### PR TITLE
Find busses on GPS after scheduled time

### DIFF
--- a/String.rb
+++ b/String.rb
@@ -1,5 +1,8 @@
 class String
-  def string_between_markers(front, back)
+  def string_between_markers(marker)
+    front = "<#{marker}>"
+    back = "</#{marker}>"
+
     self[/#{Regexp.escape(front)}(.*?)#{Regexp.escape(back)}/m, 1]
   end
 


### PR DESCRIPTION
## What does this do?

Closes https://github.com/LauraAubin/Traveller/issues/6

This finds busses on GPS if they are after scheduled busses. This PR satisfies the following conditions:

- If there are **NO** GPS busses, return the first entry.
- If there is **A** GPS bus in the set of three, return the first GPS bus entry.
- If they are **ALL** GPS, return the first entry.

## How is this accomplished?

The `traverse_array_for_real_time` method first checks if the API response was blank and will return 0, which will return a string output for `no busses`. If there are responses, then we traverse all of them in search of a bus on GPS. If we reach the end of the array, then there are no busses on GPS and we will return the first scheduled bus.

The `is_real_time` gets the adjustment value as a float because 0.35 for example is not an integer. We also check if the adjustment value is less than or greater than 0 because sometimes I have observed `adjustment_value: -2`.

## Tophat

This was tested successfully under the following conditions:

- 0 represents a bus on schedule
- 1 represents a bus on GPS
- _ represents no bus is present

```
0 0 0
0 1 0
1 0 0
1 0 1
1 1 0
1 1 1
1 _ _
0 _ _
1 0 _
_ _ _
```